### PR TITLE
Add Graphite Completions

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -73,6 +73,8 @@ autoload -U +X bashcompinit && bashcompinit
 complete -o nospace -C /opt/homebrew/bin/terraform terraform
 # Set up Git/FZF completions
 source ~/development-configuration/zsh-other-files/fzf-git-shortcuts.zsh
+# Set up Graphite Completions
+source ~/development-configuration/zsh-other-files/graphite-completions.zsh
 # ------------------------------------------------------------------------#
 # Aliases
 alias reload="source ~/.zshrc"

--- a/development-configuration/zsh-other-files/graphite-completions.zsh
+++ b/development-configuration/zsh-other-files/graphite-completions.zsh
@@ -1,0 +1,20 @@
+#compdef gt
+###-begin-gt-completions-###
+#
+# yargs command completion script
+#
+# Installation: gt completion >> ~/.zshrc
+#    or gt completion >> ~/.zprofile on OSX.
+#
+_gt_yargs_completions()
+{
+  local reply
+  local si=$IFS
+  IFS=$'
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" gt --get-yargs-completions "${words[@]}"))
+  IFS=$si
+  _describe 'values' reply
+}
+compdef _gt_yargs_completions gt
+###-end-gt-completions-###
+


### PR DESCRIPTION
### TL;DR

Added Graphite command-line tool (gt) completions to the Zsh configuration.

### What changed?

- Updated `.zshrc` to source a new file containing Graphite completions.
- Created a new file `graphite-completions.zsh` with the completion script for the Graphite CLI tool.

### Why make this change?

This change enhances the command-line experience when using the Graphite CLI tool by providing autocompletion for its commands and options. This improvement will increase productivity and reduce errors when working with Graphite in the terminal.