### PR TITLE
Remove Terraform and AWS Timeout Scripts from TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,4 +3,3 @@
 1. Add Git Worktree scripts to add and remove worktrees
 2. Consider using Bat to override help command - [documentation](https://github.com/sharkdp/bat/blob/master/README.md?plain=1#L241)
 3. Add Eza config file
-4. `terraform_check_timeout.sh` and `aws_check_timeout.sh` scripts


### PR DESCRIPTION
### TL;DR

Removed `terraform_check_timeout.sh` and `aws_check_timeout.sh` scripts from TODO list.

### What changed?

The TODO.md file has been updated to remove the last item, which mentioned the `terraform_check_timeout.sh` and `aws_check_timeout.sh` scripts. 

### Why make this change?

The scripts have been completed and as such no longer need completing.