### PR TITLE
Add GitHub Labels and Sync Workflow

### DIFF
--- a/.github/other-configs/labels.yml
+++ b/.github/other-configs/labels.yml
@@ -1,0 +1,70 @@
+# Default GitHub labels
+- color: d73a4a
+  name: bug
+  description: Something isn't working
+- color: 0075ca
+  name: documentation
+  description: Improvements or additions to documentation
+- color: 0366d6
+  name: dependencies
+  description: Pull requests that update a dependency file
+- color: cfd3d7
+  name: duplicate
+  description: This issue or pull request already exists
+- color: a2eeef
+  name: enhancement
+  description: Functionality that enhances existing features
+- color: 7057ff
+  name: good first issue
+  description: Good for newcomers
+- color: 008672
+  name: help wanted
+  description: We are looking for community help
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: d876e3
+  name: wontfix
+  description: The issue is expected and will not be fixed
+# Languages
+- color: 000000
+  name: github_actions
+  description: Pull requests that update GitHub Actions code
+- color: 66A615
+  name: just
+  description: Pull requests that update Just code
+- color: 00ff44
+  name: shell
+  description: Pull requests that update Shell code
+- color: 1900ff
+  name: Markdown
+  description: Pull requests that update Markdown documentation
+# Components
+- color: f27100
+  name: brew
+  description: Pull requests that update brewfile
+- color: ff0073
+  name: git_hooks
+  description: Pull requests that update git hooks
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,26 @@
+name: "Sync labels"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/other-configurations/labels.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  configure-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: micnncim/action-label-syncer@v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          manifest: .github/other-configs/labels.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new label configuration file and a GitHub Actions workflow to automatically sync labels with the repository.

## What changed?

- Added `.github/other-configs/labels.yml`:
  - Defined default GitHub labels with colours and descriptions
  - Added language-specific labels for GitHub Actions, Just, Shell, and Markdown
  - Included component labels for brew and git hooks
  - Created size labels ranging from XS to XXL

- Added `.github/workflows/sync-labels.yml`:
  - Created a new workflow to synchronise labels
  - Triggers on pushes to the main branch when the labels configuration file is modified
  - Uses the `micnncim/action-label-syncer` action to apply label changes