### PR TITLE
Add Pull Request Labeller and Configuration

### DIFF
--- a/.github/other-configs/labeller.yml
+++ b/.github/other-configs/labeller.yml
@@ -1,0 +1,33 @@
+# labels auto assigned to PR, keep in sync with labels.yml
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["docs/**", "*.md", "LICENSE"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["docs/**", "*.md", "LICENSE"]
+dependencies:
+  - any:
+      - head-branch: ["^dependabot"]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile"]
+shell:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.sh", ".zshrc", "**/*.zsh"]
+brew:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Brewfile"]
+github_actions:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [".github/workflows/*", ".github/workflows/**/*"]
+git_hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/other-configs/labels.yml
+++ b/.github/other-configs/labels.yml
@@ -40,7 +40,7 @@
   name: shell
   description: Pull requests that update Shell code
 - color: 1900ff
-  name: Markdown
+  name: markdown
   description: Pull requests that update Markdown documentation
 # Components
 - color: f27100

--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,0 +1,44 @@
+name: "Pull Request Labeller"
+
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        edited,
+        unlocked,
+        labeled,
+        synchronize,
+        reopened,
+        ready_for_review,
+      ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  labeller:
+    name: Label Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/other-configs/labeller.yml
+          sync-labels: true
+
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "40": "S",
+              "100": "M",
+              "200": "L",
+              "800": "XL",
+              "2000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces an automated labelling system for pull requests, enhancing the project's organisation and workflow.

## What changed?

- Added a new file `.github/other-configs/labeller.yml`:
  - Defined rules for automatically assigning labels to pull requests based on file changes and branch names
- Updated `.github/other-configs/labels.yml`:
  - Changed the name of the "Markdown" label to lowercase "markdown"
- Added a new GitHub Actions workflow file `.github/workflows/labeller.yml`:
  - Implemented a workflow to automatically label pull requests
  - Included a step to add size labels based on the number of changes in the pull request