### PR TITLE
Update Shell Label Description

### DIFF
--- a/.github/other-configs/labels.yml
+++ b/.github/other-configs/labels.yml
@@ -38,7 +38,7 @@
   description: Pull requests that update Just code
 - color: 00ff44
   name: shell
-  description: Pull requests that update Shell code
+  description: Pull requests that update Shell code (bash or zsh)
 - color: 1900ff
   name: markdown
   description: Pull requests that update Markdown documentation


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the description of the "shell" label in the labels configuration file.

## What changed?

- Updated the description for the "shell" label in `.github/other-configs/labels.yml`:
  - Clarified that the label applies to both bash and zsh shell scripts