### PR TITLE
Add Markdown Files as Linguist-Detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.json linguist-detectable
+*.md linguist-detectable


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds Markdown files to the list of linguist-detectable file types in the .gitattributes file.

## What changed?

- Updated .gitattributes file:
  - Added `*.md linguist-detectable` to enable language detection for Markdown files