### PR TITLE
Update Branch Name from Main to Master in Checkout Script

### DIFF
--- a/development-configuration/scripts/checkout_master_and_pull.sh
+++ b/development-configuration/scripts/checkout_master_and_pull.sh
@@ -4,6 +4,6 @@
 echo "Resetting the changes in the working directory..."
 git reset --hard
 
-# Switch to the main branch and pull the changes
-echo "Switch to the main branch and pull the changes..."
-git switch main && git pull origin main
+# Switch to the master branch and pull the changes
+echo "Switch to the master branch and pull the changes..."
+git switch master && git pull origin master


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the checkout script to use the 'master' branch instead of 'main'.

## What changed?

- Updated `checkout_master_and_pull.sh`:
  - Changed branch name from 'main' to 'master' in the echo statement
  - Modified git commands to switch to and pull from the 'master' branch instead of 'main'