### PR TITLE
Fix aws_prompt_info

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -6,7 +6,6 @@ zstyle ':omz:update' mode auto
 
 # ZSH Plugins
 plugins=(
-    aws
     terraform
     git
     zsh-autosuggestions

--- a/.zshrc
+++ b/.zshrc
@@ -6,6 +6,7 @@ zstyle ':omz:update' mode auto
 
 # ZSH Plugins
 plugins=(
+    aws
     terraform
     git
     zsh-autosuggestions
@@ -28,7 +29,8 @@ fi
 
 # Initalise Oh My ZSH
 source $ZSH/oh-my-zsh.sh
-
+# Remove aws_prompt_info from right = https://github.com/ohmyzsh/ohmyzsh/discussions/10726
+RPROMPT="${RPROMPT//\$\(aws_prompt_info\)}"
 # User configuration
 # ------------------------------------------------------------------------#
 # Program Environment Variables/PATH updates


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.zshrc` file. The change removes the `aws_prompt_info` from the right prompt configuration.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L32-R33): Removed `aws_prompt_info` from `RPROMPT` to address an issue discussed in the Oh My Zsh repository.