### PR TITLE
Update Repository Labels

### DIFF
--- a/.github/other-configs/labeller.yml
+++ b/.github/other-configs/labeller.yml
@@ -7,10 +7,6 @@ markdown:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["docs/*.md", "*.md", "LICENSE",  ".github/pull_request_template.md"]
-markdown:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file: ["docs/**", "*.md", "LICENSE"]
 dependencies:
   - any:
       - head-branch: ["^dependabot"]

--- a/.github/other-configs/labeller.yml
+++ b/.github/other-configs/labeller.yml
@@ -2,7 +2,11 @@
 documentation:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["docs/**", "*.md", "LICENSE"]
+          - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["docs/*.md", "*.md", "LICENSE",  ".github/pull_request_template.md"]
 markdown:
   - any:
       - changed-files:
@@ -26,7 +30,7 @@ github_actions:
   - any:
       - changed-files:
           - any-glob-to-any-file:
-              [".github/workflows/*", ".github/workflows/**/*"]
+              [".github/workflows/*", ".github/actions/*"]
 git_hooks:
   - any:
       - changed-files:

--- a/.github/other-configs/labeller.yml
+++ b/.github/other-configs/labeller.yml
@@ -6,7 +6,13 @@ documentation:
 markdown:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["docs/*.md", "*.md", "LICENSE",  ".github/pull_request_template.md"]
+          - any-glob-to-any-file:
+              [
+                "docs/*.md",
+                "*.md",
+                "LICENSE",
+                ".github/pull_request_template.md",
+              ]
 dependencies:
   - any:
       - head-branch: ["^dependabot"]
@@ -25,8 +31,7 @@ brew:
 github_actions:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [".github/workflows/*", ".github/actions/*"]
+          - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
 git_hooks:
   - any:
       - changed-files:

--- a/.github/other-configs/labels.yml
+++ b/.github/other-configs/labels.yml
@@ -42,6 +42,9 @@
 - color: 1900ff
   name: markdown
   description: Pull requests that update Markdown documentation
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
 # Components
 - color: f27100
   name: brew

--- a/.github/other-configs/labels.yml
+++ b/.github/other-configs/labels.yml
@@ -42,9 +42,6 @@
 - color: 1900ff
   name: markdown
   description: Pull requests that update Markdown documentation
-- color: 1900ff
-  name: markdown
-  description: Pull requests that update Markdown documentation
 # Components
 - color: f27100
   name: brew


### PR DESCRIPTION
## Description

This pull request includes updates to the `.github/other-configs/labeller.yml` and `.github/other-configs/labels.yml` files to improve the labeling configuration for documentation, markdown, and GitHub actions.

Labeling configuration updates:

* [`.github/other-configs/labeller.yml`](diffhunk://#diff-b98efd81d493834a02c6a37eab5defdb637a6c95a1382567c6ca211ba16174b2L5-R9): Updated the `documentation` and `markdown` sections to include more specific file patterns for labeling changes.
* [`.github/other-configs/labeller.yml`](diffhunk://#diff-b98efd81d493834a02c6a37eab5defdb637a6c95a1382567c6ca211ba16174b2L29-R29): Modified the `github_actions` section to include `.github/actions/*` in addition to `.github/workflows/*` for labeling changes.

Label definition update:

* [`.github/other-configs/labels.yml`](diffhunk://#diff-2e7c23e626fa8c338aa942fce55a914e6e08b1643901fdd722f4168ea42c78fbR45-R47): Added a duplicate entry for the `markdown` label with the same color and description.
