### PR TITLE
Add Actionlint Job

### DIFF
--- a/.github/super-linter-configs/.yaml-lint.yml
+++ b/.github/super-linter-configs/.yaml-lint.yml
@@ -4,3 +4,4 @@ rules:
   document-start: disable
   truthy: disable
   line-length: disable
+  comments: disable

--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -54,9 +54,22 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
       - name: Set up Just
         uses: extractions/setup-just@v2
-
       - name: Check Justfile Format
         run: just just-format-check
+
+  run-actionlint:
+    name: Check GitHub Actions with actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github` configuration files to enhance the linting rules and update the GitHub Actions workflow. The most important changes include disabling comments linting in the YAML linter configuration and adding a new job to check GitHub Actions using actionlint.

Enhancements to linting rules:

* [`.github/super-linter-configs/.yaml-lint.yml`](diffhunk://#diff-cdea8bea457c52a8c0651465a847dcbc52c6abd1fb370c531b89a3214efad8bbR7): Disabled comments linting by adding `comments: disable` to the rules.

Updates to GitHub Actions workflow:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L57-R75): Added a new job named `run-actionlint` to check GitHub Actions with actionlint, including steps to install actionlint and check workflow files.
