### PR TITLE
Restrict Workflow Permissions

### DIFF
--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -8,13 +8,14 @@ on:
 
 permissions:
   contents: read
-  packages: read
-  statuses: write
 
 jobs:
   check-code-quality:
     name: Check Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   labeller:
     name: Label Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Label Pull Request
         uses: actions/labeler@v5.0.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,13 +7,14 @@ on:
     paths:
       - .github/other-configs/labels.yml
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   configure-labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the GitHub Actions workflows to adjust the permissions configuration. The most important changes involve moving permissions settings into the specific jobs within each workflow file.

Changes to GitHub Actions workflows:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L11-R18): Moved `packages` and `statuses` permissions from the workflow level to the `check-code-quality` job.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL7-R14): Removed `pull-requests` write permission from the workflow level and added it to the `labeller` job.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L10-R17): Removed `contents` and `pull-requests` permissions from the workflow level and added them to the `configure-labels` job.
