### PR TITLE
Remove Actionlint Job

### DIFF
--- a/.github/super-linter-configs/.yaml-lint.yml
+++ b/.github/super-linter-configs/.yaml-lint.yml
@@ -4,4 +4,5 @@ rules:
   document-start: disable
   truthy: disable
   line-length: disable
-  comments: disable
+  comments:
+    min-spaces-from-content: 1

--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -63,21 +63,6 @@ jobs:
       - name: Check Justfile Format
         run: just just-format-check
 
-  run-actionlint:
-    name: Check GitHub Actions with actionlint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]
-
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the YAML linting configuration and the GitHub Actions workflow. The most important changes involve enabling a specific rule for comments in the YAML linting configuration and removing a job that checks GitHub Actions with actionlint.

Updates to YAML linting configuration:

* [`.github/super-linter-configs/.yaml-lint.yml`](diffhunk://#diff-cdea8bea457c52a8c0651465a847dcbc52c6abd1fb370c531b89a3214efad8bbL7-R8): Enabled the `min-spaces-from-content` rule for comments to ensure there is at least one space between comments and content.

Changes to GitHub Actions workflow:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L66-L80): Removed the `run-actionlint` job, which included steps to install and run actionlint for checking workflow files.
