### PR TITLE
Add Ghostty Theme to Config

### DIFF
--- a/ghostty-config.toml
+++ b/ghostty-config.toml
@@ -1,2 +1,3 @@
 font-family = "FiraCode Nerd Font Mono"
 font-size = 16
+theme = "Solarized Dark Higher Contrast"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `ghostty-config.toml` file. The change sets the theme to "Solarized Dark Higher Contrast".

* [`ghostty-config.toml`](diffhunk://#diff-d7fa7187e6e1798b41fcabe130fcf5fab4176d65f156e37db03e6b0ec7409181R3): Added a new theme configuration with "Solarized Dark Higher Contrast".
