### PR TITLE
Add Base Project Command

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -99,5 +99,6 @@ alias branch_cleanup="bash ~/development-configuration/scripts/remove_all_branch
 alias rebase="bash ~/development-configuration/scripts/rebase_and_push.sh"
 alias main="bash ~/development-configuration/scripts/checkout_main_and_pull.sh"
 alias master="bash ~/development-configuration/scripts/checkout_master_and_pull.sh"
+alias project="bash ~/development-configuration/scripts/project_switch.sh"
 
 . "$HOME/.local/bin/env"

--- a/development-configuration/commands.md
+++ b/development-configuration/commands.md
@@ -4,7 +4,7 @@
 
 `show_tree` - Show the tree of the current directory.
 `pretty` - Run prettier on the current directory.
-`project` - Select a project and open VSCode.
+`project` - Select a project and open Visual Studio Code.
 
 ## Git
 

--- a/development-configuration/commands.md
+++ b/development-configuration/commands.md
@@ -4,6 +4,7 @@
 
 `show_tree` - Show the tree of the current directory.
 `pretty` - Run prettier on the current directory.
+`project` - Select a project and open VSCode.
 
 ## Git
 

--- a/development-configuration/scripts/project_switch.sh
+++ b/development-configuration/scripts/project_switch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# find projects projects/personal -type d | fzf
+
+
+z switch $1
+
+code .

--- a/development-configuration/scripts/project_switch.sh
+++ b/development-configuration/scripts/project_switch.sh
@@ -2,7 +2,6 @@
 
 # find projects projects/personal -type d | fzf
 
-
 z switch "$1"
 
 code .

--- a/development-configuration/scripts/project_switch.sh
+++ b/development-configuration/scripts/project_switch.sh
@@ -3,6 +3,6 @@
 # find projects projects/personal -type d | fzf
 
 
-z switch $1
+z switch "$1"
 
 code .


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes the addition of a new script and related aliases to facilitate project switching and opening Visual Studio Code from the terminal.

New script and alias additions:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R102): Added a new alias `project` to switch projects and open Visual Studio Code using the new script `project_switch.sh`.
* [`development-configuration/commands.md`](diffhunk://#diff-b973a06d51f4776a2fc046d251a6474d6858f68e87e01cd2b67fffa71e8050a2R7): Documented the new `project` command which allows users to select a project and open Visual Studio Code.
* [`development-configuration/scripts/project_switch.sh`](diffhunk://#diff-0025f21d6966a8f727538a7c28425a7a6f9d343cd927b85e60913b54ace9612dR1-R8): Added a new script to handle project switching and opening Visual Studio Code.
