### PR TITLE
Upgrade Markdown Link Checker

### DIFF
--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -33,7 +33,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configs/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an update to the `.github/workflows/check-everything.yml` file to ensure the workflow uses the latest versions of relevant tools.

Workflow updates:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L36-R44): Changed `runs-on` from `ubuntu-22.04` to `ubuntu-latest` to always use the latest Ubuntu version.
* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L36-R44): Updated `UmbrellaDocs/action-linkspector` from version `v1.2.4` to `v1.2.5` to use the latest version of the action.