### PR TITLE
Update Rebase Command to rebase onto default repo branch

### DIFF
--- a/development-configuration/scripts/rebase_and_push.sh
+++ b/development-configuration/scripts/rebase_and_push.sh
@@ -4,8 +4,11 @@
 echo "Fetching the latest changes from the remote repository..."
 git fetch
 
+# Get default branch name
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+
 # Get the branch name from the command line argument
-branch="${1:-origin/main}"
+branch="${1:-origin/$default_branch}"
 
 # Rebase current branch with the specified branch
 echo "Rebasing the current branch with the specified branch..."


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an improvement to the `development-configuration/scripts/rebase_and_push.sh` script to dynamically determine the default branch name. This change ensures that the script works correctly regardless of the default branch name in the remote repository.

Key change:

* [`development-configuration/scripts/rebase_and_push.sh`](diffhunk://#diff-a48b64a3263aad9492def58e3a6852352c5e85cd1b4d63ed8469a5a39874035cR7-R11): Added a command to dynamically fetch the default branch name from the remote repository and use it for rebasing, replacing the hardcoded `main` branch.