### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configs/.linkspector.yml
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.1
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -87,7 +87,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.12
+        uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.1
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -120,10 +120,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.12
+        uses: github/codeql-action/init@v3.28.13
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configs/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.12
+        uses: github/codeql-action/analyze@v3.28.13


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to various GitHub Actions used in the `.github/workflows/code-checks.yml` file. The updates focus on upgrading the versions of the actions to ensure the latest features and fixes are included.

Version updates in `.github/workflows/code-checks.yml`:

* Updated `UmbrellaDocs/action-linkspector` action from `v1.3.1` to `v1.3.2` to check Markdown links.
* Updated `astral-sh/setup-uv` action from `v5.3.1` to `v5.4.0` to install the latest version of uv. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L82-R90) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L105-R105)
* Updated `github/codeql-action/upload-sarif` action from `v3.28.12` to `v3.28.13` to upload SARIF files.
* Updated `github/codeql-action/init` action from `v3.28.12` to `v3.28.13` to initialize CodeQL.
* Updated `github/codeql-action/analyze` action from `v3.28.12` to `v3.28.13` to perform CodeQL analysis.