### PR TITLE
Bump astral-sh/setup-uv to v6.0.1

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run Lefthook Validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/code-checks.yml` file to use the latest version of the `uv` setup action, ensuring compatibility and access to the latest features and fixes.

Workflow updates:

* Updated the `uv` setup action from version `v5.4.1` to `v6.0.1` in two places within the `jobs:` section of the workflow file. (`[[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L82-R82)`, `[[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L105-R105)`)