### PR TITLE
Update Default Python 3.9 to Python 3.13

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -86,7 +86,7 @@ source ~/development-configuration/zsh-other-files/oh-my-posh-completions.zsh
 # Aliases
 alias reload="source ~/.zshrc"
 alias lg=lazygit
-alias python='python3.9'
+alias python='python3.13'
 alias cd=z
 alias cat="bat"
 alias show="eza"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Python version alias in the `.zshrc` file.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383L89-R89): Updated the `python` alias to point to Python 3.13 instead of Python 3.9.