### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -80,10 +80,10 @@ jobs:
           persist-credentials: false
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-        with:
-          version: "latest"
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow for running code checks and modifies the `Justfile` to streamline the execution of Zizmor commands. The most important changes include replacing the `uv` setup with a `Just` setup in the GitHub Actions workflow and adding a new command in the `Justfile` for generating SARIF output.

### Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L83-R86): Replaced the setup of `uv` with the setup of `Just` in the GitHub Actions workflow. The `zizmor` command is now run using `just zizmor-check-sarif` instead of `uvx zizmor`.

### Command updates in `Justfile`:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL47-R51): Updated the `zizmor-check` command to use `uvx` instead of `zizmor` directly. Added a new `zizmor-check-sarif` command to generate SARIF output for Zizmor checks.