### PR TITLE
Bump actions/dependency-review-action to 4.7.0

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -46,6 +46,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
+        uses: actions/dependency-review-action@38ecb5b593bf0eb19e335c03f97670f792489a8b # v4.7.0
         with:
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `dependency-review-action` used in the GitHub Actions workflow. 

Workflow update:

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL49-R49): Updated the `dependency-review-action` from version `v4.6.0` to `v4.7.0` to ensure the workflow uses the latest version of the action.