### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `.github/other-configurations/codeql-config.yml` file. The change removes a query filter that excluded the `actions/unpinned-tag` query from CodeQL analysis.

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Removed the exclusion of the `actions/unpinned-tag` query, allowing this query to be included in CodeQL scans.