### PR TITLE
Add Chrome Extensions to Tools

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -12,6 +12,7 @@
       - [Zsh Plugins](#zsh-plugins)
     - [Applications](#applications)
     - [Web Applications](#web-applications)
+    - [Chrome Extensions](#chrome-extensions)
     - [Python Tools](#python-tools)
 
 ## Tools I Use
@@ -50,11 +51,15 @@ These are tools I am using and have found useful.
 ### Applications
 
 - [devtoys](https://github.com/DevToys-app/DevToys)
-- [freeter](https://github.com/FreeterApp/Freeter)
 
 ### Web Applications
 
 - [Graphite](https://graphite.dev/)
+
+### Chrome Extensions
+
+- [Harper](https://chromewebstore.google.com/detail/private-grammar-checking/lodbfhdipoipcjmlebjbgmmgekckhpfb)
+- [Refined GitHub](https://chromewebstore.google.com/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf)
 
 ### Python Tools
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `TOOLS.md` file to include a new section for Chrome Extensions and removes a deprecated application. The most important changes are as follows:

### Additions:
* Added a new section titled "Chrome Extensions" under the tools list, along with links to two extensions: [Harper](https://chromewebstore.google.com/detail/private-grammar-checking/lodbfhdipoipcjmlebjbgmmgekckhpfb) and [Refined GitHub](https://chromewebstore.google.com/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf). [[1]](diffhunk://#diff-806f3d0616e18ff8209e430b5c718c62e4a2f6ad6f2d4b2b2f21ad7c7e9d7f52R15) [[2]](diffhunk://#diff-806f3d0616e18ff8209e430b5c718c62e4a2f6ad6f2d4b2b2f21ad7c7e9d7f52L53-R63)

### Removals:
* Removed the link to the deprecated application "Freeter" from the "Applications" section.