### PR TITLE
Bump Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,6 +51,6 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the reusable workflow versions across multiple GitHub Actions workflow files to ensure compatibility and incorporate the latest improvements. The updated workflows include `clean-caches`, `code-checks`, `codeql-analysis`, `pull-request-tasks`, and `sync-labels`.

Updates to reusable workflow versions:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated `common-clean-caches.yml` reusable workflow to version `v2025.06.04.02`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L42-R42): Updated `common-code-checks.yml` reusable workflow to version `v2025.06.04.02`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L54-R54): Updated `codeql-analysis.yml` reusable workflow to version `v2025.06.04.02`.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15): Updated `common-pull-request-tasks.yml` reusable workflow to version `v2025.06.04.02`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Updated `common-sync-labels.yml` reusable workflow to version `v2025.06.04.02`.