### PR TITLE
Add Material Icons for GitHub extension

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -49,16 +49,17 @@ These are tools I am using and have found useful.
 ### Applications
 
 - [devtoys](https://github.com/DevToys-app/DevToys)
-- [raycast](https://www.raycast.com/)
+- [Raycast](https://www.raycast.com/)
 
 ### Chrome Extensions
 
 - [Harper](https://chromewebstore.google.com/detail/private-grammar-checking/lodbfhdipoipcjmlebjbgmmgekckhpfb)
 - [Refined GitHub](https://chromewebstore.google.com/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf)
 - [Le Git Graph](https://github.com/NirmalScaria/le-git-graph)
-- [raycast](https://chromewebstore.google.com/detail/raycast-companion/fgacdjnoljjfikkadhogeofgjoglooma)
 - [Entropy](https://chromewebstore.google.com/detail/entropy-extension-auto-bl/jfglacfdockpdpbfodkipgcjplgnojel)
   - [Site](https://entropysec.io/)
+- [Raycast](https://chromewebstore.google.com/detail/raycast-companion/fgacdjnoljjfikkadhogeofgjoglooma)
+- [Material Icons for GitHub](https://chromewebstore.google.com/detail/material-icons-for-github/bggfcpfjbdkhfhfmkjpbhnkhnpjjeomc)
 
 ### Python Tools
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes updates to the `TOOLS.md` file to improve formatting and add a new Chrome extension to the list of tools.

Changes to formatting:

* Capitalized "Raycast" in the Applications section to ensure consistent naming.

Additions to the tools list:

* Added "Material Icons for GitHub" to the Chrome Extensions section.