### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:

--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -4,7 +4,7 @@
 .gitattributes
 .github
 Brewfile
-LICENSE
+LICENCE
 README.md
 TODO.md
 TOOLS.md


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the repository by correcting the spelling of the license file from `LICENSE` to `LICENCE` in configuration files.

* Updated the file path from `LICENSE` to `LICENCE` in `.github/other-configurations/labeller.yml` to ensure proper labeling of markdown files.
* Changed the ignore pattern from `LICENSE` to `LICENCE` in `.stow-local-ignore` for consistency with the new file name.