### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@1a353cd8db3393047830eaa51f6ce11eac29f94b # v2025.08.21.05
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@1a353cd8db3393047830eaa51f6ce11eac29f94b # v2025.08.21.05
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -34,6 +34,6 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@1a353cd8db3393047830eaa51f6ce11eac29f94b # v2025.08.21.05
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@1a353cd8db3393047830eaa51f6ce11eac29f94b # v2025.08.21.05
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@3247419e78d8921f39ce9bb46d47787a3b5f537b # v2025.08.04.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@1a353cd8db3393047830eaa51f6ce11eac29f94b # v2025.08.21.05
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to use newer versions of their respective reusable workflows. The main change is bumping the referenced reusable workflow commit hashes to a more recent version, which likely includes bug fixes, improvements, or updated dependencies.

**Workflow version updates:**

* Updated `common-code-checks.yml`, `codeql-analysis.yml`, `common-clean-caches.yml`, `common-pull-request-tasks.yml`, and `common-sync-labels.yml` references in their respective workflow files to use the commit `1a353cd8db3393047830eaa51f6ce11eac29f94b` (v2025.08.21.05) instead of `3247419e78d8921f39ce9bb46d47787a3b5f537b` (v2025.08.04.01). This ensures all workflows are running the latest shared logic and improvements. (`.github/workflows/code-checks.yml` [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L25-R25) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L37-R37); `.github/workflows/clean-caches.yml` [[3]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15); `.github/workflows/pull-request-tasks.yml` [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15); `.github/workflows/sync-labels.yml` [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19)