### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -110,4 +110,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the pre-commit tooling to use the latest version of Prek and makes minor adjustments to the update workflow. The most important changes are grouped below:

**Prek version and configuration updates:**

* Updated the minimum required Prek version from `0.3.0` to `0.4.0` in `.pre-commit-config.yaml` to ensure compatibility with newer features and fixes.

**Update workflow adjustments:**

* Changed the `prek-update-hooks` command in the `Justfile` to use `prek update --freeze` instead of `prek autoupdate`, which may improve reproducibility by freezing dependency versions.
* Removed the call to `prek-update-additional-dependencies` from the main `update` workflow in the `Justfile`, streamlining the update process.